### PR TITLE
Allow empty value to be used for color picker

### DIFF
--- a/functions/helpers.php
+++ b/functions/helpers.php
@@ -479,14 +479,13 @@ if ( ! function_exists('tr_is_json')) {
     }
 }
 
-if ( ! function_exists('tr_frontend')) {
+if ( ! function_exists('tr_is_frontend')) {
     /**
-     * Enable TypeRocket on the front end of the website
+     * Check if the frontend is being used
      */
-    function tr_frontend()
+    function tr_is_frontend()
     {
-        $core = new TypeRocket\Core\Launcher();
-        $core->initFrontEnd();
+        return !is_admin();
     }
 }
 

--- a/src/Core/Config.php
+++ b/src/Core/Config.php
@@ -18,10 +18,6 @@ class Config
         if(is_file($root . '/app.php')) {
             self::$config['app'] = require( $root . '/app.php' );
         }
-        self::$config['typerocket'] = [
-            'frontend' => false,
-            'post_messages' => true
-        ];
     }
 
     /**
@@ -77,18 +73,4 @@ class Config
 
         return $value;
     }
-
-    /**
-     * Set Live TypeRocket Configs
-     *
-     * @param string $dots dot notation key.next.final
-     * @param mixed $value
-     *
-     * @return array
-     */
-    public static function typerocket($dots, $value)
-    {
-        return dots_set($dots, self::$config['typerocket'], $value);
-    }
-
 }

--- a/src/Core/Launcher.php
+++ b/src/Core/Launcher.php
@@ -23,6 +23,7 @@ class Launcher
         $this->initHooks();
         $this->loadPlugins();
         $this->loadResponders();
+        $this->initFrontEnd();
 
         /*
         |--------------------------------------------------------------------------
@@ -122,7 +123,10 @@ class Launcher
      */
     public function initFrontEnd()
     {
-        Config::typerocket('frontend', true);
+        if ( !tr_is_frontend() || !Config::locate('typerocket.frontend.assets') ) {
+            return;
+        }
+
         add_action( 'wp_enqueue_scripts', [ $this, 'addCss' ] );
         add_action( 'wp_enqueue_scripts', [ $this, 'addJs' ] );
         add_action( 'wp_footer', [ $this, 'addBottomJs' ] );

--- a/src/Elements/Fields/Color.php
+++ b/src/Elements/Fields/Color.php
@@ -48,7 +48,7 @@ class Color extends Field implements ScriptField
 
         add_action('admin_footer', $callback, 999999999999 );
 
-        if( Config::getFrontend() ) {
+        if ( tr_is_frontend() && Config::locate('typerocket.frontend.assets') ) {
             add_action('wp_footer', $callback, 999999999999 );
         }
 

--- a/src/Elements/Fields/Color.php
+++ b/src/Elements/Fields/Color.php
@@ -34,7 +34,7 @@ class Color extends Field implements ScriptField
         $value = $this->getValue();
         $default = $this->getDefault();
         $value = !empty($value) ? $value : $default;
-        $value =  Sanitize::hex( $value );
+        $value = !empty($value) ? Sanitize::hex( $value ) : null;
 
         $this->removeAttribute( 'name' );
         $this->appendStringToAttribute( 'class', ' color-picker' );


### PR DESCRIPTION
This fixes an issue with the color picker on 4.0 and allow an empty value (no color) to be used.