### PR TITLE
LIKE is not working due to changes in $wpdb->prepapre

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -813,6 +813,8 @@ class Query
             $prepared = $wpdb->prepare( '%s', $value );
         }
 
+        $prepared = $wpdb->remove_placeholder_escape($prepared);
+
         return $prepared;
     }
 


### PR DESCRIPTION
LIKE is not working due to changes in WordPress security release. Link to release [here](https://wordpress.org/news/2017/10/wordpress-4-8-3-security-release/) and [here](https://make.wordpress.org/core/2017/10/31/changed-behaviour-of-esc_sql-in-wordpress-4-8-3/)

```
echo $wpdb->prepapre( "%search_value" );
// "{9fa52f39262a451892931117b9ab11b5a06d3a15faee833cc75edb18b4411d11}search_value"
 
echo $wpdb->remove_placeholder_escape( $wpdb->prepapre( "%search_value" ) );
// "%search_value"
```