### PR TITLE
Enqueue tinymce scripts in case first instance is ajax

### DIFF
--- a/src/Elements/Fields/Builder.php
+++ b/src/Elements/Fields/Builder.php
@@ -41,6 +41,11 @@ class Builder extends Matrix
      */
     public function getString()
     {
+        // enqueue tinymce
+        echo '<div style="display: none; visibility: hidden;">';
+        wp_editor('', 'tr_dummy_editor');
+        echo '</div>';
+
         $this->setAttribute('name', $this->getNameAttributeString() );
         $buffer = new Buffer();
         $buffer->startBuffer();

--- a/src/Elements/Fields/Matrix.php
+++ b/src/Elements/Fields/Matrix.php
@@ -60,6 +60,12 @@ class Matrix extends Field implements ScriptField {
      */
     public function getString()
     {
+
+        // enqueue tinymce
+        echo '<div style="display: none; visibility: hidden;">';
+        wp_editor('', 'tr_dummy_editor');
+        echo '</div>';
+
         $this->setAttribute('name', $this->getNameAttributeString());
 
         // setup select list of files


### PR DESCRIPTION
This is hacky... but wp doesn't provide a way to decouple the scripts from the editor itself... so we have a hidden editor in case the first tinymce instance is via ajax.