### PR TITLE
Add conditional logic API

### DIFF
--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -13,4 +13,5 @@ require('./tooling/matrix');
 require('./tooling/media');
 require('./tooling/seo');
 require('./tooling/toggle');
+require('./tooling/conditions');
 trBuilder();

--- a/assets/js/tooling/conditions.js
+++ b/assets/js/tooling/conditions.js
@@ -199,7 +199,7 @@ jQuery.fn.extend({
     return $(this).parents('[class*="typerocket-elements-fields"]').first()
   },
   getOuterWrapper: function() {
-    return $(this).parents('.tr-repeater-group, [id*="tab-panel"], .builder-field-group, .postbox-container').first()
+    return $(this).parents('.tr-repeater-group, [id*="tab-panel"], .builder-field-group, .postbox-container, #wpbody').first()
   }
 })
 

--- a/assets/js/tooling/conditions.js
+++ b/assets/js/tooling/conditions.js
@@ -7,18 +7,24 @@ class ConditionalLogic {
    */
   initializeChangingFields($template = null) {
 
-    var $conditions = this.$scope.find('[data-conditions]')
+    var $scope = this.$scope
 
-    if($template && !$template.target) $conditions = $template.find('[data-conditions]')
+    if($template && !$template.target) $scope = $template
+
+    var $conditions = $scope.find('[data-conditions]')
 
     $conditions.each(function(index, item) {
 
-      if(!$(item).data('conditional-name') && $(item).attr('name')) {
-        $(item).attr('data-conditional-name', $(item).attr('name') + '[' + index + ']')
+      if($(item).parents('.tr-repeater-group-template').first().length) return true
+
+      var $item = $(item)
+
+      if(!$item.data('conditional-name') && $item.attr('name')) {
+        $item.attr('data-conditional-name', $item.attr('name') + '[' + index + ']')
       }
 
-      var conditions = $(item).getConditions(),
-        $wrapper = $(item).getOuterWrapper()
+      var conditions = $item.getConditions(),
+        $wrapper = $item.getOuterWrapper()
 
       for(var c in conditions) {
 
@@ -30,7 +36,7 @@ class ConditionalLogic {
             $field = $wrapper.find('[name*="[' + condition.field + ']"]'),
             conditionalFields = $field.data('conditional-fields') ? $field.data('conditional-fields') : []
 
-          conditionalFields.push($(item).data('conditional-name'))
+          conditionalFields.push($item.data('conditional-name'))
 
           $field.addClass('has-conditional-fields').data('conditional-fields', conditionalFields)
 
@@ -193,6 +199,7 @@ class ConditionalLogic {
 
 jQuery.fn.extend({
   getConditions: function() {
+    if(typeof $(this).data('conditions') == 'undefined') return
     return JSON.parse($(this).data('conditions').replace(/'/g, '"'))
   },
   getFieldWrapper: function() {

--- a/assets/js/tooling/conditions.js
+++ b/assets/js/tooling/conditions.js
@@ -206,7 +206,7 @@ jQuery.fn.extend({
     return $(this).parents('[class*="typerocket-elements-fields"]').first()
   },
   getOuterWrapper: function() {
-    return $(this).parents('.tr-repeater-group, [id*="tab-panel"], .builder-field-group, .postbox-container, #wpbody').first()
+    return $(this).parents('.tr-repeater-group, [id*="tab-panel"], .builder-field-group, .postbox, #wpbody').first()
   }
 })
 

--- a/assets/js/tooling/conditions.js
+++ b/assets/js/tooling/conditions.js
@@ -1,0 +1,209 @@
+class ConditionalLogic {
+
+
+  /**
+   * [initializeChangingFields description]
+   * @return {null}
+   */
+  initializeChangingFields($template = null) {
+
+    var $conditions = this.$scope.find('[data-conditions]')
+
+    if($template && !$template.target) $conditions = $template.find('[data-conditions]')
+
+    $conditions.each(function(index, item) {
+
+      if(!$(item).data('conditional-name') && $(item).attr('name')) {
+        $(item).attr('data-conditional-name', $(item).attr('name') + '[' + index + ']')
+      }
+
+      var conditions = $(item).getConditions(),
+        $wrapper = $(item).getOuterWrapper()
+
+      for(var c in conditions) {
+
+        var rules = conditions[c]
+
+        for(var r in rules) {
+
+          var condition = rules[r],
+            $field = $wrapper.find('[name*="[' + condition.field + ']"]'),
+            conditionalFields = $field.data('conditional-fields') ? $field.data('conditional-fields') : []
+
+          conditionalFields.push($(item).data('conditional-name'))
+
+          $field.addClass('has-conditional-fields').data('conditional-fields', conditionalFields)
+
+        }
+
+      }
+
+    })
+
+    setTimeout(function() {
+      jQuery('.has-conditional-fields').each(function() {
+        jQuery(this).trigger('change')
+      })
+    }, 10)
+
+  }
+
+
+  /**
+   * show/hide conditional fields
+   * @param  {event} e
+   * @return {null}
+   */
+  toggleFields(e) {
+
+    var $this = $(e.currentTarget),
+      conditionalFields = $this.data('conditional-fields')
+
+    for(var i in conditionalFields) {
+
+      var $conditionalField = $('[data-conditional-name="' + conditionalFields[i] + '"]'),
+        conditions = $conditionalField.getConditions()
+
+      this.hideField($conditionalField)
+
+      for(var c in conditions) {
+        var rules = conditions[c]
+        if(this.conditionsMet($this.getOuterWrapper(), rules)) {
+          this.showField($conditionalField)
+        }
+        this.toggleTab($conditionalField.getFieldWrapper())
+      }
+
+    }
+
+  }
+
+
+  /**
+   * [hideField description]
+   * @param  {jQuery object} $field
+   * @return {null}
+   */
+  hideField($field) {
+    $field.getFieldWrapper().hide()
+    $field.data('required', $field.prop('required'))
+    $field.attr('name', '')
+    $field.prop('required', false)
+  }
+
+
+  /**
+   * [showField description]
+   * @param  {jQuery object} $field
+   * @return {null}
+   */
+  showField($field) {
+    $field.getFieldWrapper().show()
+    $field.attr('name', $field.data('conditional-name').replace(/\[\d+\]$/, ''))
+    $field.prop('required', $field.data('required'))
+  }
+
+
+  /**
+   * [conditionsMet description]
+   * @param  {jQuery object} $field
+   * @param  {array} rules
+   * @return {boolean}
+   */
+  conditionsMet($wrapper, rules) {
+    var met = 0
+    for(var i in rules) {
+      var condition = rules[i],
+        $field = $wrapper.find('[name*="[' + condition.field + ']"]'),
+        // operator = condition.operator,
+        value = condition.value
+      if($field.length && this.conditionMet($field, value)) {
+        met++
+      }
+    }
+    return met == rules.length
+  }
+
+
+  /**
+   * [conditionMet description]
+   * @param  {jQuery object} $field
+   * @param  {string} value
+   * @return {boolean}
+   */
+  conditionMet($field, value) {
+    var type = $field.attr('type'),
+      tagName = $field.prop('tagName')
+    if(type == 'checkbox' || type == 'radio') {
+      if($field.filter(':checked').val() == value) {
+        return true
+      } else if(type == 'checkbox' && $field.prop('checked')) {
+        return true
+      }
+    } else if(tagName.toLowerCase() == 'select') {
+      if($field.find(':selected').val() == value) {
+        return true
+      }
+    }
+    return false
+  }
+
+
+  /**
+   * [toggleTab description]
+   * @param  {jQuery object} $wrapper
+   * @return {null}
+   */
+  toggleTab($wrapper) {
+    var $tab = $wrapper.parents('.tab-section').first(),
+      $tabLink = jQuery('a[href="#' + $tab.attr('id') + '"]').parent(),
+      $visibleElements = $tab.find('> div').filter(function() {
+        return $(this).css('display') != 'none'
+      })
+
+    $tabLink.hide()
+    if($visibleElements.length) $tabLink.show()
+  }
+
+
+  /**
+   * [init description]
+   * @return {null}
+   */
+  init() {
+    jQuery(window).on('load', this.initializeChangingFields.bind(this))
+
+    jQuery(document).on('change', '.has-conditional-fields', this.toggleFields.bind(this))
+
+    TypeRocket.repeaterCallbacks.push(this.initializeChangingFields.bind(this))
+  }
+
+
+  /**
+   * [constructor description]
+   * @param {string} scope
+   */
+  constructor(scope) {
+    this.$scope = jQuery(scope)
+    this.init()
+  }
+
+}
+
+
+jQuery.fn.extend({
+  getConditions: function() {
+    return JSON.parse($(this).data('conditions').replace(/'/g, '"'))
+  },
+  getFieldWrapper: function() {
+    return $(this).parents('[class*="typerocket-elements-fields"]').first()
+  },
+  getOuterWrapper: function() {
+    return $(this).parents('.tr-repeater-group, [id*="tab-panel"], .builder-field-group, .postbox-container').first()
+  }
+})
+
+
+jQuery(document).ready(function() {
+  new ConditionalLogic('body')
+})

--- a/src/Elements/Fields/Field.php
+++ b/src/Elements/Fields/Field.php
@@ -386,6 +386,28 @@ abstract class Field
     }
 
     /**
+     * Add conditional logic.
+     * @param array $conditions Array of conditional logic arguments.
+     *                          [
+     *                            [
+     *                              'field' => 'field_name',
+     *                              'operator' => '=',
+     *                              'value' => 'Show this field'
+     *                            ]
+     *                          ]
+     *                          Will show the current field object
+     *                          if conditions are met.
+     * @return $this
+     */
+    public function setConditions($conditions)
+    {
+        $conditions = json_encode($conditions);
+        $conditions = str_replace('"', '\'', $conditions);
+        $this->setAttribute('data-conditions', $conditions);
+        return $this;
+    }
+
+    /**
      * Sanitize field value
      *
      * @param $value

--- a/src/Elements/Fields/Field.php
+++ b/src/Elements/Fields/Field.php
@@ -391,7 +391,6 @@ abstract class Field
      *                          [
      *                            [
      *                              'field' => 'field_name',
-     *                              'operator' => '=',
      *                              'value' => 'Show this field'
      *                            ]
      *                          ]


### PR DESCRIPTION
The API works like this:

```php
echo $form->radio('choices')->setOptions([
  'Choice 1' => 'choice-1',
  'Choice 2' => 'choice-2'
]);

echo $form->text('conditional field')->setConditions([
  [
    [
      'field' => 'choices',
      'value' => 'choice-2'
    ]
  ]
]);
```

You can combine arguments in the "inner" array(s), which creates an AND relationship, or you can add arrays to the "outer" array to create an OR.

```php
echo $form->text('conditional field')->setConditions([
  [
    [
      'field' => 'choices',
      'value' => 'choice-2'
    ], // this is an AND
    [
      'field' => 'example',
      'value' => 'example'
    ]
  ], // this is an OR
  [
    [
      'field' => 'example',
      'value' => 'example'
    ]
  ]
]);
```

If all the conditions evaluate to `true`, the field will be shown.

For the `field` argument, the API ignores nesting/prefixing within groups, repeater, builder, and matrix, but prefers fields that are closer to the affected field in the DOM. So, there is no need to include brackets or dots in your `field`. If you have a field with the same name that is farther away from the field you want to toggle, you must rename it. To facilitate this, the API searches within "groups" of fields of decreasing proximity. Here is the order of precedence:

1. Repeater row
2. Tab panel
3. Builder component
4. Meta box
5. `#wpbody` (the main WP admin content element)

The API does _not_ care, however, if you have a hidden field and a shown field with the same name. It will always save the value of the displayed field and ignore the hidden one.