### PR TITLE
Has Many Repeater

### DIFF
--- a/assets/js/tooling/typerocket.js
+++ b/assets/js/tooling/typerocket.js
@@ -34,7 +34,7 @@ jQuery(document).ready(function($) {
             if ($repeater_fields.length > 0) {
                 $repeater_fields.sortable({
                     connectWith: '.tr-repeater-group',
-                    handle: '.repeater-controls',
+                    handle: '.repeater-controls.sortable',
                     placeholder: "tr-sortable-placeholder",
                     forcePlaceholderSize: true
                 });
@@ -226,6 +226,17 @@ jQuery(document).ready(function($) {
                 });
                 e.preventDefault();
             });
+            jQuery( document ).on( 'click', '.hasmany .toggle-child', function () {
+                if ( jQuery( this ).hasClass( 'tr-control-icon-remove' ) ) {
+                    jQuery( this ).removeClass( 'tr-control-icon-remove' ).addClass( 'tr-control-icon-restore' );
+                    jQuery( this ).parent().parent().find( '.delete-child' ).val( 1 );
+                    jQuery( this ).parent().parent().addClass( 'delete-record' );
+                } else {
+                    jQuery( this ).removeClass( 'tr-control-icon-restore' ).addClass( 'tr-control-icon-remove' );
+                    jQuery( this ).parent().parent().find( '.delete-child' ).val( 0 );
+                    jQuery( this ).parent().parent().removeClass( 'delete-record' );
+                }
+            } );
             $(document).on('click', '.tr-repeater .repeater-controls .collapse', function(e) {
                 var $group;
                 $group = $(this).parent().parent();

--- a/assets/sass/utility/icon-controls.scss
+++ b/assets/sass/utility/icon-controls.scss
@@ -28,6 +28,10 @@
     content: "\f335";
 }
 
+.tr-control-icon-restore:before {
+    content: "\f317";
+}
+
 .tr-control-icon-remove:hover {
     color: $delete_hover;
 }

--- a/assets/sass/utility/repeater.scss
+++ b/assets/sass/utility/repeater.scss
@@ -28,6 +28,11 @@
     &:last-child {
         margin-bottom: 0px;
     }
+
+}
+
+.delete-record {
+    background-color: rgba(233, 204, 204, 1) !important;
 }
 
 .tr-repeater-fields > .tr-sortable-placeholder {
@@ -45,7 +50,10 @@
     z-index: 2;
     color: #333;
     background: #f5f5f5;
-    cursor: move;
+
+    &.sortable {
+        cursor: move;
+    }
 
     [class*="tr-control-icon"] {
         padding: 9px 0;
@@ -53,7 +61,7 @@
         left: 0;
     }
 
-    .tr-control-icon-remove {
+    .tr-control-icon-remove, .tr-control-icon-restore {
         bottom: 0;
         z-index: 3;
     }

--- a/src/Controllers/WPPostController.php
+++ b/src/Controllers/WPPostController.php
@@ -31,35 +31,99 @@ class WPPostController extends Controller
      *
      * @return mixed|void
      */
-    public function update( $id = null )
-    {
-        $post = $this->model->findById( $id );
+	public function update( $id = null ) {
+		$fields          = $this->request->getFields();
+		$has_many_fields = null;
 
-        try {
-            $post->update( $this->request->getFields() );
-            $this->response->flashNext($this->type . ' updated', 'success' );
-            $this->response->setData('resourceId', $id );
-        } catch ( ModelException $e ) {
-            $this->response->flashNext($e->getMessage(), 'error' );
-            $this->response->setError( 'model', $e->getMessage() );
-        }
+		foreach ( $fields as $name => $data ) {
+			if ( $name == 'hasmany' ) {
+				$has_many_fields = $data;
+				unset( $fields['hasmany'] );
+			}
+		}
 
-    }
+		$post = $this->model->findById( $id );
+
+		try {
+			$post->update( $fields );
+			$this->response->flashNext( $this->type . ' updated', 'success' );
+			$this->response->setData( 'resourceId', $id );
+			if( $has_many_fields ) {
+				$this->saveRelated( $has_many_fields, $id );
+			}
+		} catch ( ModelException $e ) {
+			$this->response->flashNext( $e->getMessage(), 'error' );
+			$this->response->setError( 'model', $e->getMessage() );
+		}
+
+	}
 
     /**
      * Create Post
      */
-    public function create()
-    {
-        try {
-            $this->model->create( $this->request->getFields() );
-            $this->response->flashNext($this->type . ' created', 'success' );
-            $this->response->setStatus(201);
-            $this->response->setData('resourceId', $this->model->getID());
-        } catch ( ModelException $e ) {
-            $this->response->flashNext($e->getMessage(), 'error' );
-            $this->response->setError( 'model', $e->getMessage() );
-        }
+	public function create() {
+		$fields          = $this->request->getFields();
+		$has_many_fields = null;
 
-    }
+		foreach ( $fields as $name => $data ) {
+			if ( $name == 'hasmany' ) {
+				$has_many_fields = $data;
+				unset( $fields['hasmany'] );
+			}
+		}
+
+		try {
+			$this->model->create( $fields );
+			$this->response->flashNext( $this->type . ' created', 'success' );
+			$this->response->setStatus( 201 );
+			$this->response->setData( 'resourceId', $this->model->getID() );
+			if( $has_many_fields ) {
+				$this->saveRelated( $has_many_fields, $this->model->getID() );
+			}
+		} catch ( ModelException $e ) {
+			$this->response->flashNext( $e->getMessage(), 'error' );
+			$this->response->setError( 'model', $e->getMessage() );
+		}
+
+	}
+
+	/**
+	 * Iterate through related records and create, update, or delete them
+	 * 
+	 * @param $models
+	 * @param $foreign_key
+	 */
+	private function saveRelated( $models, $foreign_key ) {
+		if ( $models ) {
+			foreach ( $models as $model => $records ) {
+				$model             = "\\App\\Models\\" . $model;
+				$foreign_key_field = ( $records['foreignkey'] );
+				unset( $records['foreignkey'] );
+				$sort_field = null;
+				if ( isset( $records['sortfield'] ) ) {
+					$sort_field = $records['sortfield'];
+					unset( $records['sortfield'] );
+				}
+				$i = 0;
+				foreach ( $records as $id => $fields ) {
+					$newmodel = new $model();
+					if ( isset( $fields['delete'] ) && $fields['delete'] == 1 ) {
+						$newmodel->delete( [ $id ] );
+					} else {
+						unset( $fields['delete'] );
+						if ( strlen( (string) $id ) < 13 ) {
+							$newmodel->setProperty( 'id', $id );
+						}
+						$fields[ $foreign_key_field ] = $foreign_key;
+						if ( $sort_field ) {
+							$fields[ $sort_field ] = $i;
+						}
+						$newmodel->save( $fields );
+						$i ++;
+
+					}
+				}
+			}
+		}
+	}
 }

--- a/src/Elements/Fields/HasManyRepeater.php
+++ b/src/Elements/Fields/HasManyRepeater.php
@@ -1,0 +1,264 @@
+<?php
+
+namespace TypeRocket\Elements\Fields;
+
+use \TypeRocket\Elements\Fields\Repeater;
+use \TypeRocket\Html\Generator;
+use TypeRocket\Html\Tag;
+
+class HasManyRepeater extends Repeater {
+
+	protected $relatedModel;
+	protected $relatedResource;
+	protected $foreignKey;
+	protected $sortField = null;
+	protected $orderBy = 'id';
+	protected $orderByDirection = 'ASC';
+	protected $limit = null;
+
+	public function __construct( $related_resource, $foreign_key, $form, $attr = [], $settings = [], $label = true ) {
+
+		$related_model = "\\" . TR_APP_NAMESPACE . "\\Models\\" . $related_resource;
+
+		$this->relatedResource = $related_resource;
+		$this->relatedModel    = ( new $related_model )->where( $foreign_key, $form->getItemId() );
+		$this->foreignKey      = $foreign_key;
+
+		parent::__construct( $related_resource, $attr, $settings, $label, $form );
+
+	}
+
+	/**
+	 * sets what database field the repeater should sort by when displaying records
+	 *
+	 * @param null $column
+	 * @param string $direction
+	 *
+	 * @return $this
+	 */
+
+	public function orderBy( $column = null, $direction = 'ASC' ) {
+		$this->relatedModel->orderBy( $column, $direction );
+
+		return $this;
+	}
+
+	/**
+	 * limits the number of records that are retrieved for the repeater; combine with setOrderBy to get the results you want
+	 *
+	 * @param $limit
+	 * @param int $offset
+	 * @param bool $returnOne
+	 *
+	 * @return $this
+	 */
+
+	public function take( $limit, $offset = 0, $returnOne = true ) {
+		$this->relatedModel->take( $limit, $offset, $returnOne );
+
+		return $this;
+	}
+
+	/**
+	 * adds an additional where condition to the repeater record query
+	 *
+	 * @param $column
+	 * @param $arg1
+	 * @param null $arg2
+	 * @param string $condition
+	 *
+	 * @return $this
+	 */
+
+	public function where( $column, $arg1, $arg2 = null, $condition = 'AND' ) {
+		$this->relatedModel->where( $column, $arg1, $arg2, $condition );
+
+		return $this;
+	}
+
+	/**
+	 * adds an OR where condition to the repeater record query
+	 *
+	 * @param $column
+	 * @param $arg1
+	 * @param null $arg2
+	 *
+	 * @return $this
+	 */
+
+	public function orWhere( $column, $arg1, $arg2 = null ) {
+		$this->relatedModel->where( $column, $arg1, $arg2, 'OR' );
+
+		return $this;
+	}
+
+	/**
+	 * allows the user to manually sort the Repeater fields; saves the sort order into the provided field in the database ($index_field)
+	 *
+	 * @param $sort_field
+	 *
+	 * @return $this
+	 */
+
+	public function sortable( $sort_field ) {
+		$this->sortField = $sort_field;
+		$this->orderBy( $sort_field );
+
+		return $this;
+	}
+
+	/**
+	 * gets the number of rows and their IDs from the related table for the repeater - this overrides the base model getValue method so that it will look at the related table instead of the parent table
+	 *
+	 * @return array|null|string
+	 */
+
+	public function getValue() {
+
+		if ( $this->populate == false ) {
+			return null;
+		}
+
+		$results = $this->relatedModel->get();
+
+		$return = [];
+		if ( $results ) {
+			foreach ( $results as $row ) {
+				$return[ $row->id ] = $row->id;
+			}
+		}
+
+		return $return;
+	}
+
+	/**
+	 * generates the repeater control and populates it with the appropriate data - this overrides the getString method in the Repeater class
+	 *
+	 * @return string
+	 */
+
+	/**
+	 * Covert Repeater to HTML string
+	 */
+	public function getString() {
+		$this->setAttribute( 'name', $this->getNameAttributeString() );
+		$form     = $this->getForm();
+		$settings = $this->getSettings();
+		$name     = $this->relatedResource;
+		$form->setDebugStatus( false );
+		$html         = $fields_classes = '';
+		$group_prefix = 'hasmany';
+
+		$headline = $this->headline ? '<h1>' . $this->headline . '</h1>' : '';
+
+		// add controls
+		if ( isset( $settings['help'] ) ) {
+			$help = "<div class=\"help\"> <p>{$settings['help']}</p> </div>";
+			$this->removeSetting( 'help' );
+		} else {
+			$help = '';
+		}
+
+		// add collapsed / contracted
+		if ( ! empty( $settings['contracted'] ) ) {
+			$fields_classes = ' tr-repeater-collapse';
+		}
+
+		// add button settings
+		if ( isset( $settings['add_button'] ) ) {
+			$add_button_value = $settings['add_button'];
+		} else {
+			$add_button_value = "Add New";
+		}
+
+		$controls = [
+			'contract' => 'Contract',
+			'flip'     => 'Flip',
+			'clear'    => 'Clear All',
+			'add'      => $add_button_value,
+		];
+
+		// controls settings
+		if ( isset( $settings['controls'] ) && is_array( $settings['controls'] ) ) {
+			$controls = array_merge( $controls, $settings['controls'] );
+		}
+
+		// escape controls
+		$controls = array_map( function ( $item ) {
+			return esc_attr( $item );
+		}, $controls );
+
+		// template for repeater groups
+		$href          = '#remove';
+		$openContainer = '<div class="repeater-controls"><div class="collapse"></div>';
+		$openContainer .= $this->sortField ? '<div class="move"></div>' : '';
+		$openContainer .='<a href="' . $href . '" class="toggle-child remove-child" title="remove"></a></div><div class="repeater-inputs">';
+		$endContainer  = '</div>';
+
+		$html .= '<div class="control-section tr-repeater">'; // start tr-repeater
+
+		// setup repeater
+		$cache_group = $form->getGroup();
+
+		$root_group = $group_prefix . "." . $this->getDots();
+		$form->setGroup( $group_prefix . "." . $this->getDots() . ".{{ {$name} }}" );
+
+		// add controls (add, flip, clear all)
+		$generator    = new Generator();
+		$default_null = $generator->newInput( 'hidden', $this->getAttribute( 'name' ), null )->getString();
+		$foreign_key  = $generator->newInput( 'hidden', "tr[" . $group_prefix . "][" . $this->getDots() . "]" . "[foreignkey]", $this->foreignKey )->getString();
+		if( $this->sortField ) {
+			$sort_field = $generator->newInput( 'hidden', "tr[" . $group_prefix . "][" . $this->getDots() . "]" . "[sortfield]", $this->sortField )->getString();
+		} else {
+			$sort_field = '';
+		}
+
+
+		$html .= "<div class=\"controls\"><div class=\"tr-repeater-button-add\"><input type=\"button\" value=\"{$controls['add']}\" class=\"button add\" /></div>{$help}<div>{$default_null}{$foreign_key}{$sort_field}</div></div>";
+
+		// replace name attr with data-name so fields are not saved
+		$templateFields = str_replace( ' name="', ' data-name="', $this->getTemplateFields() );
+
+		// render js template data
+		$html .= "<div class=\"tr-repeater-group-template\" data-id=\"{$name}\">";
+		$html .= $openContainer . $headline . $templateFields . $endContainer;
+		$html .= '</div>';
+
+		// render saved data
+		$html    .= '<div class="' . $group_prefix . ' tr-repeater-fields' . $fields_classes . '">'; // start tr-repeater-fields
+		$repeats = $this->getValue();
+		if ( is_array( $repeats ) ) {
+			foreach ( $repeats as $k => $array ) {
+				$recordform = tr_form( $this->relatedResource, 'update', $k );
+				foreach ( $this->fields as $field ) {
+					$field->form = $recordform;
+				}
+				$delete = $generator->newInput( 'hidden', "tr[" . $group_prefix . "][" . $this->getDots() . "][{$k}]" . "[delete]", null, [ 'class' => 'delete-child' ] )->getString();
+
+				$html .= '<div class="tr-repeater-group">';
+				$html .= $openContainer;
+				$recordform->setGroup( $root_group . ".{$k}" );
+				$html .= $headline;
+				$html .= $delete;
+				$html .= $recordform->getFromFieldsString( $this->fields );
+				$html .= $endContainer;
+				$html .= '</div>';
+			}
+		}
+		$html .= '</div>'; // end tr-repeater-fields
+		$form->setGroup( $cache_group );
+		$html .= '</div>'; // end tr-repeater
+
+		return $html;
+	}
+
+	/**
+	 * Get the repeater template field for JS hook
+	 *
+	 * @return string
+	 */
+
+	private function getTemplateFields() {
+		return $this->getForm()->setDebugStatus( false )->getFromFieldsString( $this->fields );
+	}
+}

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -540,6 +540,12 @@ class Model
 
         $keys = $this->getDotKeys( $field );
 
+        $do_not_parse = false;
+	    if ( $keys[0] == 'hasmany' ) {
+	    	$do_not_parse = true;
+		    $keys = array_reverse( $keys );
+	    }
+
         if( $this->old ) {
             if( ! empty($this->old[$keys[0]]) ) {
                 $data = wp_unslash( $this->old[$keys[0]] );
@@ -554,7 +560,11 @@ class Model
             return null;
         }
 
-        return $this->parseValueData( $data, $keys );
+        if( $do_not_parse ) {
+        	return $data;
+        } else {
+	        return $this->parseValueData( $data, $keys );
+        }
     }
 
     /**


### PR DESCRIPTION
Hey @kevindees, here's my proposed HasManyRepeater field.

One note: I know you mentioned that you're slow to add fields, so it still needs a decent amount of cleaning up and further testing. I didn't want to do all the work of folding it more seamlessly into core until I knew it's something you were interested in merging into master.

All that said, here's an example for you to test how it works!

We're gonna do a one-to-many relationship with Graduating Classes having many Students:
```
CREATE TABLE `wp_students` (
 `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
 `class_id` bigint(20) unsigned NOT NULL,
 `first_name` varchar(50) NOT NULL,
 `last_name` varchar(50) NOT NULL,
 `gpa` decimal(2,1) NOT NULL,
 `sort` int(11) NOT NULL DEFAULT '0',
 PRIMARY KEY (`id`),
 KEY `Class` (`class_id`),
 CONSTRAINT `Class` FOREIGN KEY (`class_id`) REFERENCES `wp_posts` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE
) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=latin1
```

And its corresponding model in typerocket/app/Models:
```
namespace App\Models;

use \TypeRocket\Models\Model;

class Student extends Model {
	protected $resource = 'students';
}
```

I have my forked version of TR with the HasManyRepeater branch installed inside a theme. In my functions.php I've got the following:
```
require( 'typerocket/init.php' );

add_action( 'typerocket_loaded', function () {
	$classes = tr_post_type( 'Graduating Class', 'Graduating Classes' );

	$classes->setTitleForm( function () {
		$form = tr_form();

		$first_name = $form->text( 'first_name' )->setLabel( 'First Name' );
		$last_name  = $form->text( 'last_name' )->setLabel( 'Last Name' );
		$gpa        = $form->text( 'gpa' )->setType( 'number' )->setLabel( 'GPA' )->setAttribute( 'step', '0.1' );

		$students   = new \TypeRocket\Elements\Fields\HasManyRepeater( 'Student', 'class_id', $form );
		$students->setFields( [
			$first_name,
			$last_name,
			$gpa
		] );
		$students->setLabel( 'Students' );

		echo $students;
	} );
} );
```

This should generate a Repeater that works almost exactly the same as your existing field, except that each record you add, update, or delete will correspond to a record in the Students table. 

Also, deleting a record doesn't remove it from the DOM like the normal Repeater, but rather highlights it in red and adds a form value that marks it for deletion when the form is updated (and this can be undone prior to form submission).

I've also added some options.

By default, sorting is disabled. You can choose to either automatically order by any field within the related table `$students->orderBy( 'first_name' )` or reactivate manual sorting by feeding the HasManyRepeater an integer field in the table dedicated to containing the sort order `$students->sortable( 'sort' )`.

In addition, I've replicated every relevant Model query method so that you can filter what gets fed into the repeater. This includes `where`, `orWhere`, `take`, and `orderBy`.

Plenty more to talk about in terms of ideas to improve the field, but I've gone on long enough. Let me know your first impressions!