### PR TITLE
Added hook so routes can be added from outside of TypeRocket

### DIFF
--- a/src/Core/Launcher.php
+++ b/src/Core/Launcher.php
@@ -48,6 +48,7 @@ class Launcher
         | Load TypeRocket Router
         |
         */
+	    do_action( 'tr_load_routes' );
         $base_dir = Config::locate('paths.base');
         $routeFile = $base_dir . '/routes.php';
         if( file_exists($routeFile) ) {


### PR DESCRIPTION
Adds a hook in Launcher.php so routes can be added from outside of TypeRocket (e.g. from plugins).