### PR TITLE
Reserved taxonomies

### DIFF
--- a/src/Register/Registrable.php
+++ b/src/Register/Registrable.php
@@ -195,6 +195,15 @@ abstract class Registrable
         }
     }
 
+	protected function isReserved()
+	{
+		if (in_array($this->id, $this->reservedNames)) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
     /**
      * Use other Registrable objects or string IDs
      *

--- a/src/Register/Taxonomy.php
+++ b/src/Register/Taxonomy.php
@@ -182,16 +182,16 @@ class Taxonomy extends Registrable
      *
      * @return $this
      */
-    public function register()
-    {
-        $this->dieIfReserved();
+	public function register()
+	{
+		if( ! $this->isReserved() ) {
+			do_action( 'tr_register_taxonomy_' . $this->id, $this );
+			register_taxonomy( $this->id, $this->postTypes, $this->args );
+		}
+		Registry::addTaxonomyResource($this->id, $this->resource);
 
-        do_action( 'tr_register_taxonomy_' . $this->id, $this );
-        register_taxonomy( $this->id, $this->postTypes, $this->args );
-        Registry::addTaxonomyResource($this->id, $this->resource);
-
-        return $this;
-    }
+		return $this;
+	}
 
     /**
      * Apply post types


### PR DESCRIPTION
Allows `tr_taxonomy` to be used with reserved taxonomies so custom form fields can be added.