### PR TITLE
Allow page template rule to be used for any post type

### DIFF
--- a/src/Register/MetaBox.php
+++ b/src/Register/MetaBox.php
@@ -174,7 +174,7 @@ class MetaBox extends Registrable
                     $this->id,
                     $this->label,
                     $callback,
-                    $isPageTemplate || $isFrontPage || $isPostsPage ? 'page' : $screen,
+                    $isPageTemplate || $isFrontPage || $isPostsPage ? $postType : $screen,
                     $this->context,
                     $this->priority
                 );


### PR DESCRIPTION
https://developer.wordpress.org/themes/template-files-section/page-template-files/#creating-page-templates-for-specific-post-types