### PR TITLE
Adds Ability to Change the Primary Column in Post Types

### DIFF
--- a/src/Register/PostType.php
+++ b/src/Register/PostType.php
@@ -14,6 +14,7 @@ class PostType extends Registrable
     protected $form = [];
     protected $taxonomies = [];
     protected $columns = [];
+    protected $primaryColumn = null;
     protected $metaBoxes = [];
     protected $archiveQuery = [];
     protected $icon = null;
@@ -422,6 +423,28 @@ class PostType extends Registrable
      */
     public function getColumns() {
         return $this->columns;
+    }
+
+	/**
+	 * Set Primary Column that will contain the "Edit | Quick Edit | Trash | View" controls
+	 *
+	 * @param $field
+	 *
+	 * @return $this
+	 */
+    public function setPrimaryColumn( $field ) {
+    	$this->primaryColumn = $field;
+
+    	return $this;
+    }
+
+	/**
+	 * Get Primary Column
+	 *
+	 * @return null
+	 */
+    public function getPrimaryColumn() {
+    	return $this->primaryColumn;
     }
 
     /**

--- a/src/Register/Registry.php
+++ b/src/Register/Registry.php
@@ -267,6 +267,7 @@ class Registry
     {
         $pt = $post_type->getId();
         $new_columns = $post_type->getColumns();
+	    $primary_column = $post_type->getPrimaryColumn();
 
         add_filter( "manage_edit-{$pt}_columns" , function($columns) use ($new_columns) {
             foreach ($new_columns as $key => $new_column) {
@@ -300,6 +301,17 @@ class Registry
                 }
             }
         }, 10, 2);
+
+	    if( $primary_column ) {
+		    add_filter( 'list_table_primary_column', function ( $default, $screen ) use ( $pt, $primary_column ) {
+
+			    if ( $screen === 'edit-' . $pt ){
+				    $default = $primary_column;
+			    }
+
+			    return $default;
+		    }, 10, 2 );
+	    }
 
         foreach ($new_columns as $new_column) {
             if(!empty($new_column['sort'])) {


### PR DESCRIPTION
'setPrimaryColumn' on custom post type will allow "Edit | Quick Edit | Trash | View" controls to be moved from the Title column to one of your choosing.