### PR TITLE
Adding HTML Between FieldRow Fields

### DIFF
--- a/src/Elements/FieldRow.php
+++ b/src/Elements/FieldRow.php
@@ -52,7 +52,9 @@ class FieldRow
         }
 
         foreach( $this->fields as $field) {
-            if( $field instanceof Field ) {
+        	if( $field instanceof Generator ) {
+        		$fieldsHtml .= $field;
+	        } elseif( $field instanceof Field ) {
                 $fieldsHtml .= (string) $field;
             } elseif( $field instanceof FieldColumn ) {
                 $this->hasColumns = true;

--- a/src/Elements/Form.php
+++ b/src/Elements/Form.php
@@ -692,6 +692,20 @@ class Form
         return new FieldRow( $fields );
     }
 
+	/**
+	 * Add text between fields in row
+	 *
+	 * @param $content
+	 *
+	 * @return Generator
+	 */
+    public function rowText( $content ) {
+    	$generator = new Generator;
+    	$generator->newElement( 'div', ['class' => 'control-section'], $content );
+
+    	return $generator;
+    }
+
     /**
      * Get fields as row
      *


### PR DESCRIPTION
I wanted to be able to add some HTML between fields in the FieldRow class, but when iterating over the array you feed to `$form->row()` it ignores anything that isn't a Field or FieldColumn. This allows Generator content to be included and adds a helper method on the Form class to make it easy.

Here's an example implementation:
```
	$test->setTitleForm( function () {
		$form = tr_form();
		$start_date = $form->text( 'Start Date' )->setType( 'date' );
		$to         = $form->rowText( 'to' );
		$end_date   = $form->text( 'End Date' )->setType( 'date' );
		$date_range = $form->row( [
			$start_date,
			$to,
			$end_date
		] );
		echo $date_range;
	} );
```

Obviously some CSS needs to be cleaned up to keep the text from being given as much width as the fields (which looks really funny). I'd be happy to do that if this is something you're willing to fold in.