### PR TITLE
Spoof destroy method on delete_post action in WPPostController

### DIFF
--- a/src/Controllers/WPPostController.php
+++ b/src/Controllers/WPPostController.php
@@ -63,8 +63,12 @@ class WPPostController extends Controller
 
     }
 
+	/**
+	 * Delete Post
+	 */
     public function destroy()
     {
-
+    	//override this method to spoof delete_post action
     }
+
 }

--- a/src/Controllers/WPPostController.php
+++ b/src/Controllers/WPPostController.php
@@ -62,4 +62,9 @@ class WPPostController extends Controller
         }
 
     }
+
+    public function destroy()
+    {
+
+    }
 }

--- a/src/Core/Launcher.php
+++ b/src/Core/Launcher.php
@@ -190,6 +190,7 @@ class Launcher
         }
 
         add_action( 'save_post', 'TypeRocket\Http\Responders\Hook::posts' );
+        add_action( 'delete_post', 'TypeRocket\Http\Responders\Hook::posts' );
         add_action( 'wp_insert_comment', 'TypeRocket\Http\Responders\Hook::comments' );
         add_action( 'edit_comment', 'TypeRocket\Http\Responders\Hook::comments' );
         add_action( 'edit_term', 'TypeRocket\Http\Responders\Hook::taxonomies', 10, 4 );

--- a/src/Http/Responders/PostsResponder.php
+++ b/src/Http/Responders/PostsResponder.php
@@ -21,6 +21,15 @@ class PostsResponder extends Responder
     {
         $postId = $args['id'];
 
+        $action = current_action();
+        if( $action == 'save_post' ) {
+        	$action = 'update';
+	        $method = 'PUT';
+        } elseif ( $action == 'delete_post' ) {
+        	$action = 'delete';
+        	$method = 'DELETE';
+        }
+
         if ( ! $id = wp_is_post_revision( $postId ) ) {
             $id = $postId;
         }
@@ -36,7 +45,7 @@ class PostsResponder extends Responder
             $resource = 'post';
         }
 
-        $request  = new Request( $resource, 'PUT', $args, 'update', $this->hook );
+        $request  = new Request( $resource, $method, $args, $action, $this->hook );
         $response = new Response();
         $response->blockFlash();
 

--- a/src/Models/WPPost.php
+++ b/src/Models/WPPost.php
@@ -226,6 +226,11 @@ class WPPost extends Model
         return $this;
     }
 
+    public function delete( $ids = [] ) {
+    	//echo 'test';
+    	//die();
+    }
+
     /**
      * Save post meta fields from TypeRocket fields
      *

--- a/src/Models/WPPost.php
+++ b/src/Models/WPPost.php
@@ -226,11 +226,6 @@ class WPPost extends Model
         return $this;
     }
 
-    public function delete( $ids = [] ) {
-    	//echo 'test';
-    	//die();
-    }
-
     /**
      * Save post meta fields from TypeRocket fields
      *


### PR DESCRIPTION
RE: https://github.com/TypeRocket/typerocket/issues/177

Curious if you're happy with this implementation. I wasn't sure if it would be better to alter the `respond` method in PostsResponder or create an all new method for spoofing destroy specifically. I opted for the former.

At this point, I also haven't actually implemented anything other than an empty `destroy` method in WPPostController as this is sufficient for what I need (being able to override that method and do other stuff on deletion of certain post types).

If this matches the way you would like it to be designed, I can do the same for comments, terms, and users.