### PR TITLE
optimize custom route hook location

### DIFF
--- a/src/Http/Routes.php
+++ b/src/Http/Routes.php
@@ -47,6 +47,10 @@ class Routes
     public function initHooks()
     {
         if( ! is_admin() ) {
+            add_action( 'init', function() {
+                $this->route();
+            } );
+
             add_filter('template_include', Closure::bind(function( $template ) {
                 $this->route();
                 return $template;


### PR DESCRIPTION
Run custom route as soon as possible, just after user authenticated, before WP doing its request parsing.