### PR TITLE
Optional Util

### DIFF
--- a/functions/helpers.php
+++ b/functions/helpers.php
@@ -1010,3 +1010,15 @@ if ( ! function_exists('tr_config')) {
     }
 }
 
+if ( ! function_exists( 'tr_optional' ) ) {
+    /**
+     * Gracefully call object properties and methods
+     *
+     * @param  object $object
+     * @return \TypeRocket\Utility\Optional
+     */
+    function tr_optional( $object )
+    {
+      return new \TypeRocket\Utility\Optional( $object );
+    }
+}

--- a/src/Utility/Optional.php
+++ b/src/Utility/Optional.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace TypeRocket\Utility;
+
+class Optional
+{
+    /**
+     * @var object
+     */
+    private $object;
+
+    /**
+     * Optional constructor
+     *
+     * @param object $object
+     */
+    public function __construct( $object )
+    {
+        $this->object = $object;
+    }
+
+    /**
+     * Gracefully get the object property or return null for non-objects
+     *
+     * @param  string $name
+     * @return mixed|null
+     */
+    public function __get( $name )
+    {
+        if ( ! empty( $this->object ) && ! empty( $this->object->{$name} ) ) {
+            return $this->object->{$name};
+        }
+
+        return null;
+    }
+
+    /**
+     * Gracefully call the object method or return null for non-objects
+     *
+     * @param  string $name
+     * @param  array  $arguments
+     * @return mixed|null
+     */
+    public function __call( $name, $arguments )
+    {
+        if ( ! empty( $this->object ) && method_exists( $this->object, $name ) ) {
+           return call_user_func_array( array( $this->object, $name ), $arguments );
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
A utility helper function for gracefully calling objects properties and methods, avoiding `Trying to get property of non-object` and similar errors.

This is inspired by [Laravel optional helper function](https://laravel.com/docs/7.x/helpers#method-optional).

```php
return tr_optional( $user )->name; // Returns the name if exists and null if the user is null
return tr_optional( $user )->getLocation(); // Returns the location if exists and null if the user is null

// Very powerful with model relationships
return tr_optional( $post->author )->name; // Returns null if the post author is deleted
```