### PR TITLE
Fix the many-to-many id selection bug in Model and EagerLoader

### DIFF
--- a/src/Database/EagerLoader.php
+++ b/src/Database/EagerLoader.php
@@ -255,13 +255,18 @@ class EagerLoader
         $query = $relation->getRelatedBy()['query'];
         $set = [];
 
+        $relationId = $query['where_column'];
+        if (($pos = strpos($relationId, ".")) !== false) { 
+            $relationId = substr($relationId, $pos + 1); 
+        }
+
         if($result instanceof Results) {
             foreach($result as $model) {
                 /** @var Model $model */
-                $ids[] = $model->getId();
+                $ids[] = $model->$relationId ?? $model->getId();
             }
         } elseif($result instanceof Model) {
-            $ids[] = $result->getId();
+            $ids[] = $result->$relationId ?? $result->getId();
         }
 
         $relation

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -1674,12 +1674,12 @@ class Model implements Formable, JsonSerializable
      */
     public function belongsToMany( $modelClass, $junction_table, $id_column = null, $id_foreign = null, $scope = null, $reselect = true )
     {
-        $id = $this->getID();
-
         // Column ID
         if( ! $id_column && $this->resource ) {
             $id_column =  $this->resource . '_id';
         }
+
+        $id = $this->$id_column ?? $this->getID();
 
         /** @var Model $relationship */
         $relationship = new $modelClass;


### PR DESCRIPTION
This bug fix will pull the Id for many-to-many relationships from the given `$id_column` instead of always using the default Model id column.