### PR TITLE
Fix passing `null` to `ltrim()`

### DIFF
--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -277,8 +277,11 @@ class Command extends SymfonyCommand
             define('TYPEROCKET_GALAXY_MAKE_NAMESPACE', Helper::appNamespace());
         }
 
-        $space = $append ? "\\" . TYPEROCKET_GALAXY_MAKE_NAMESPACE . "\\" : TYPEROCKET_GALAXY_MAKE_NAMESPACE;
-        return $space . ltrim($append, '\\');
+		if (!is_string($append)) {
+			return TYPEROCKET_GALAXY_MAKE_NAMESPACE;
+		}
+
+		return "\\" . TYPEROCKET_GALAXY_MAKE_NAMESPACE . "\\" . ltrim($append, '\\');
     }
 
 }


### PR DESCRIPTION
In `TypeRocket\Console\Command`, the `getGalaxyMakeNamespace()` method uses the `$append` var to decide whether to extend the namespace prefix for the command being created.

The error below was triggered by running `ltrim()` on `$append` when it was set to `null`, which is deprecated in PHP 8.2.

Since the existing ternary resulted in the constant `TYPEROCKET_GALAXY_MAKE_NAMESPACE` being returned outright anyway, this is now the direct behavior.

And as a result, the final return statement is only reachable when `$append` is a string.

```
[ErrorException]                                                              
  ltrim(): Passing null to parameter #1 ($string) of type string is deprecated  
                                                                                

Exception trace:
  at /app/wp-content/plugins/typerocket-v6/typerocket/vendor/typerocket/core/src/Console/Command.php:281
 Spatie\Ignition\Ignition->renderError() at n/a:n/a
 ltrim() at /app/wp-content/plugins/typerocket-v6/typerocket/vendor/typerocket/core/src/Console/Command.php:281
 TypeRocket\Console\Command->getGalaxyMakeNamespace() at /app/wp-content/plugins/typerocket-v6/typerocket/vendor/typerocket/core/src/Console/Commands/MakeModel.php:80
 TypeRocket\Console\Commands\MakeModel->makeFile() at /app/wp-content/plugins/typerocket-v6/typerocket/vendor/typerocket/core/src/Console/Commands/MakeModel.php:63
 TypeRocket\Console\Commands\MakeModel->exec() at /app/wp-content/plugins/typerocket-v6/typerocket/vendor/typerocket/core/src/Console/Command.php:109
 TypeRocket\Console\Command->execute() at /app/vendor/symfony/console/Command/Command.php:326
 Symfony\Component\Console\Command\Command->run() at /app/wp-content/plugins/typerocket-v6/typerocket/vendor/symfony/console/Application.php:1014
 Symfony\Component\Console\Application->doRunCommand() at /app/wp-content/plugins/typerocket-v6/typerocket/vendor/symfony/console/Application.php:301
 Symfony\Component\Console\Application->doRun() at /app/wp-content/plugins/typerocket-v6/typerocket/vendor/symfony/console/Application.php:171
 Symfony\Component\Console\Application->run() at /app/wp-content/plugins/typerocket-v6/typerocket/vendor/typerocket/core/src/Console/GalaxyConsoleLauncher.php:116
 TypeRocket\Console\GalaxyConsoleLauncher->loadCommandsAndRun() at /app/wp-includes/class-wp-hook.php:322
 WP_Hook->apply_filters() at /app/wp-includes/class-wp-hook.php:348
 WP_Hook->do_action() at /app/wp-includes/plugin.php:517
 do_action() at /app/wp-settings.php:621
 require_once() at /app/wp-config.php:193
 require_once() at /app/wp-load.php:50
 require() at /app/wp-content/plugins/typerocket-v6/typerocket/vendor/typerocket/core/src/Console/GalaxyConsoleLauncher.php:64
 TypeRocket\Console\GalaxyConsoleLauncher->__construct() at /app/galaxy:20
```