### PR TITLE
Use correct parent model for `hasOne` relationships

### DIFF
--- a/src/Database/EagerLoader.php
+++ b/src/Database/EagerLoader.php
@@ -181,7 +181,7 @@ class EagerLoader
         if($result instanceof Results) {
             foreach($result as $key => $value) {
                 /** @var Model $value */
-                $local_id = $model->getPropertyValueDirect($query['id_local']);
+                $local_id = $value->getPropertyValueDirect($query['id_local']);
                 $value->setRelationship($name, $set[$local_id] ?? null);
             }
         } else {


### PR DESCRIPTION
When eager-loading `hasOne` relationships on a collection of parent models, it always uses the last parent assigned to `$model` further up in the method call.

This is fixed by using `$value` inside the loop where the relationship is loaded.