### PR TITLE
Ensure `$request->getQueryAsArray()` passes string to `parse_str()`

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -386,7 +386,7 @@ class Request
      */
     public function getQueryAsArray()
     {
-		$query_str = parse_url($this->getUriFull(), PHP_URL_QUERY);
+        $query_str = parse_url($this->getUriFull(), PHP_URL_QUERY);
 
         parse_str(is_string($query_str) ? $query_str : "", $request_params);
 

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -386,7 +386,9 @@ class Request
      */
     public function getQueryAsArray()
     {
-        parse_str(parse_url($this->getUriFull(), PHP_URL_QUERY), $request_params);
+		$query_str = parse_url($this->getUriFull(), PHP_URL_QUERY);
+
+        parse_str(is_string($query_str) ? $query_str : "", $request_params);
 
         return $request_params;
     }


### PR DESCRIPTION
This change ensures only a string can be passed to `parse_str()` when trying to get the query string as an array.

The function `parse_url()` can return multiple types. In particular, if 1 component of the URL is requested (like the query string), it can return a string, `null`, or `false`.

In PHP 8.1, passing `null` to `parse_str()` was deprecated. This wouldn't normally be an issue except in WordPress with `WP_DEBUG=true` or `WP_ENVIRONMENT_TYPE='development'`, warnings are treated as errors.