### PR TITLE
Use default controller in `PostsResponder` if `$controller` is not a string

### DIFF
--- a/src/Http/Responders/PostsResponder.php
+++ b/src/Http/Responders/PostsResponder.php
@@ -47,7 +47,7 @@ class PostsResponder extends Responder
         $middlewareGroup = [ $resource ,'post'];
         $model = null;
 
-        if (! class_exists( $controller ) ) {
+        if (! is_string( $controller ) || ! class_exists( $controller ) ) {
             $controller = WPPostController::class;
         }
 


### PR DESCRIPTION
In `\TypeRocket\Http\Responders\PostsResponder`, the `$controller` var starts `null`.

If the checks that follow don't modify `$controller`, it results in calling `class_exists(null)`.

Since passing `null` to string functions is deprecated as of PHP 8.1, this causes an exception to be thrown when either `WP_DEBUG=true` or `WP_ENVIRONMENT_TYPE='development'`.